### PR TITLE
Added requirement that git must be installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Buckley is an opinionated CLI tool made to help Build Teams with rapid developme
 It automates the provisioning of workstations with a set of tools and configurations to minimize time spent onboarding new team members and share good practices via tooling. 
 
 # Installation
-To get started, run: 
+To get started, make sure you have git installed, then run: 
 
 `curl https://raw.githubusercontent.com/SlalomBuildATL/buckley/master/bootstrap.sh | bash`
 


### PR DESCRIPTION
When git is not installed, the initial bootstrap script fails, but the rest of the script continues and the errors don't obviously point to git not being installed. A "try/catch" around the some of the commands would be best, but for now just clarifying that git should be installed is good enough, I think.